### PR TITLE
o is not part of Clean

### DIFF
--- a/grammars/clean.cson
+++ b/grammars/clean.cson
@@ -132,9 +132,6 @@ repository:
   operatorGeneral:
     name: 'keyword.operator.clean'
     match: '[-~@#$%^?!+*<>\/|&=:.]+'
-  operatorComposition:
-    name: 'keyword.operator.composition.clean'
-    match: '\\s+o\\s+'
 
   delimiters:
     name: 'punctuation.separator'


### PR DESCRIPTION
This is debatable, but technically `o` is not part of the Clean core but of StdEnv. So, it can be argued that it shouldn't be given special treatment. Otherwise, there is a whole gamut of functions that we may want to highlight differently as well (`$`, `>>=`, etc.).
