### PR TITLE
Character literals

### DIFF
--- a/grammars/clean.cson
+++ b/grammars/clean.cson
@@ -94,7 +94,7 @@ repository:
     ]
   literalChar:
     name: 'constant.character.clean'
-    match: '\'.\''
+    match: '\'([^\'\\\\]|\\\\(x[0-9a-fA-F]+|\\d+|.))\''
   literalInt:
     name: 'constant.numeric.integer.decimal.clean'
     match: '\\b[+-]?[0-9]+\\b'


### PR DESCRIPTION
- `'\'` is no longer matched
- `'''` is no longer matched
- `'\{Digit}+'` is matched
- `'\{Char}'` is matched
- `'\x{HexDigit}+'` is matched
